### PR TITLE
fix(run.bat): fix the error that cannot start frontend in windows

### DIFF
--- a/run.bat
+++ b/run.bat
@@ -1,4 +1,5 @@
 @echo off
+setlocal enabledelayedexpansion
 
 call :get_python3
 


### PR DESCRIPTION
## Before

 ` echo !response!` in  `run.bat` shows wrong value and causes frontend startup failure.

<img width="745" alt="c3baad38f8255692f04aa76a2af2ff8" src="https://github.com/kuafuai/DevOpsGPT/assets/5936153/1bd7db35-0172-47cc-aff6-747197ed4a53">

## After

Add `setlocal enabledelayedexpansion` in `run.bat` then ` echo !response!` in  `run.bat` shows correctly and can startup frontend.

<img width="640" alt="4453a7c98ee39035242d7d5a9af3957" src="https://github.com/kuafuai/DevOpsGPT/assets/5936153/81722b07-d8ba-4b2a-b569-6d88f19a4c4b">

