### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/backend/app/pkgs/tools/llm_basic.py
+++ b/backend/app/pkgs/tools/llm_basic.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import openai
+import litellm
 from app.pkgs.tools.llm_interface import LLMInterface
 from config import LLM_MODEL
 from config import GPT_KEYS
@@ -37,12 +38,21 @@ class LLMBase(LLMInterface):
         openai.api_key = get_next_api_key()
         print("chartGPT - get api key:"+openai.api_key, flush=True)
 
-        response = openai.ChatCompletion.create(
-            model= LLM_MODEL,
-            messages=context,
-            max_tokens=12000,
-            temperature=0,
-        )
+        if LLM_MODEL in litellm.models:
+                # see litellm supported models here: https://litellm.readthedocs.io/en/latest/supported/
+                response = litellm.completion(
+                model= LLM_MODEL,
+                messages=context,
+                max_tokens=12000,
+                temperature=0,
+            )
+        else:
+            response = openai.ChatCompletion.create(
+                model= LLM_MODEL,
+                messages=context,
+                max_tokens=12000,
+                temperature=0,
+            )
 
         response_text = response["choices"][0]["message"]["content"]
         print("chartGPT - response_text:"+response_text, flush=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ flask-cors==3.0.10
 pyyaml
 python-gitlab
 openai==0.27.8
+litellm==0.1.226


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints

This PR adds support for models from all the above mentioned providers. I added a condition to check if the provided model is supported by litellm -> if so it uses litellm for the completion call. 

If not it maintains your openai call 

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```